### PR TITLE
Spell Check

### DIFF
--- a/Part#2 - CPU/olc6502.h
+++ b/Part#2 - CPU/olc6502.h
@@ -68,7 +68,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019
+	David Barr, aka javidx9, Â©OneLoneCoder 2019
 */
 
 #pragma once
@@ -183,7 +183,7 @@ private:
 	// different instructions. Each of these are stored in a table in numerical
 	// order so they can be looked up easily, with no decoding required.
 	// Each table entry holds:
-	//	Pneumonic : A textual representation of the instruction (used for disassembly)
+	//	Mnemonic : A textual representation of the instruction (used for disassembly)
 	//	Opcode Function: A function pointer to the implementation of the opcode
 	//	Opcode Address Mode : A function pointer to the implementation of the 
     //						  addressing mechanism used by the instruction


### PR DESCRIPTION
Changed pneumonic to mnemonic. Pretty sure the intent here was a memory aid (mnemonic) not a related to the disease (pneumonic).