### PR TITLE
PHP instruction execution fix

### DIFF
--- a/Part#2 - CPU/olc6502.cpp
+++ b/Part#2 - CPU/olc6502.cpp
@@ -1237,7 +1237,7 @@ uint8_t olc6502::PHA()
 // Note:        Break flag is set to 1 before push
 uint8_t olc6502::PHP()
 {
-	write(0x0100 + stkp, status | B | U);
+	write(0x0100 + stkp, status | D | B);
 	SetFlag(B, 0);
 	SetFlag(U, 0);
 	stkp--;


### PR DESCRIPTION
After the PHP instruction is executed, bits 4 & 5 are supposed to be set on the byte pushed onto the stack.
Instead, bits 5 & 6 are. If you look at the way the status flags are represented for those 2 bits (1 << 4) & (1 << 5), it is possible that an oversight was made in the implementation of the instruction originally.
In addition, the status register should remain unchanged. The U (unused) bit is changed, which isn't really an issue since nothing is supposed to reference it (it is UNUSED, after all).

For reference:
https://wiki.nesdev.com/w/index.php/Status_flags
https://www.masswerk.at/6502/6502_instruction_set.html#LSR