### PR TITLE
Fix relative addressing mode in disassembler

### DIFF
--- a/Part#2 - CPU/olc6502.cpp
+++ b/Part#2 - CPU/olc6502.cpp
@@ -1577,7 +1577,8 @@ std::map<uint16_t, std::string> olc6502::disassemble(uint16_t nStart, uint16_t n
 		else if (lookup[opcode].addrmode == &olc6502::REL)
 		{
 			value = bus->read(addr, true); addr++;
-			sInst += "$" + hex(value, 2) + " [$" + hex(addr + value, 4) + "] {REL}";
+			int8_t rel_value = (int8_t)value;
+			sInst += "$" + hex(value, 2) + " [$" + hex(addr + rel_value, 4) + "] {REL}";
 		}
 
 		// Add the formed string to a std::map, using the instruction's


### PR DESCRIPTION
Fix calculation of the effective address in relative addressing mode in the disassembler by casting to a signed int8